### PR TITLE
Update clue scroll references to scroll box

### DIFF
--- a/src/main/java/org/CustomSounds/CustomSoundsPlugin.java
+++ b/src/main/java/org/CustomSounds/CustomSoundsPlugin.java
@@ -296,23 +296,23 @@ public class CustomSoundsPlugin extends Plugin
 		final int haPrice = itemComposition.getHaPrice() * quantity;
 		final int value = getValueByMode(gePrice, haPrice);
 
-		if (config.beginnerClueSound() && name.contains("clue scroll (beginner)")){
+		if (config.beginnerClueSound() && name.contains("scroll box (beginner)")){
 			playSound(BEGINNER_CLUE_SOUND_FILE);
 		}
-		if (config.easyClueSound() && name.contains("clue scroll (easy)")){
+		if (config.easyClueSound() && name.contains("scroll box (easy)")){
 			playSound(EASY_CLUE_SOUND_FILE);
 		}
-		if (config.mediumClueSound() && name.contains("clue scroll (medium)")){
+		if (config.mediumClueSound() && name.contains("scroll box (medium)")){
 			playSound(MEDIUM_CLUE_SOUND_FILE);
 		}
-		if (config.hardClueSound() && name.contains("clue scroll (hard)")){
+		if (config.hardClueSound() && name.contains("scroll box (hard)")){
 			playSound(HARD_CLUE_SOUND_FILE);
 		}
 
-		if (config.eliteClueSound() && name.contains("clue scroll (elite)")){
+		if (config.eliteClueSound() && name.contains("scroll box (elite)")){
 			playSound(ELITE_CLUE_SOUND_FILE);
 		}
-		if (config.masterClueSound() && name.contains("clue scroll (master)")){
+		if (config.masterClueSound() && name.contains("scroll box (master)")){
 			playSound(MASTER_CLUE_SOUND_FILE);
 		}
 

--- a/src/main/java/org/CustomSounds/CustomSoundsPlugin.java
+++ b/src/main/java/org/CustomSounds/CustomSoundsPlugin.java
@@ -296,23 +296,23 @@ public class CustomSoundsPlugin extends Plugin
 		final int haPrice = itemComposition.getHaPrice() * quantity;
 		final int value = getValueByMode(gePrice, haPrice);
 
-		if (config.beginnerClueSound() && name.contains("scroll box (beginner)")){
+		if (config.beginnerClueSound() && (name.contains("scroll box (beginner)") || name.contains("clue scroll (beginner)"))){
 			playSound(BEGINNER_CLUE_SOUND_FILE);
 		}
-		if (config.easyClueSound() && name.contains("scroll box (easy)")){
+		if (config.easyClueSound() && (name.contains("scroll box (easy)") || name.contains("clue scroll (easy)"))){
 			playSound(EASY_CLUE_SOUND_FILE);
 		}
-		if (config.mediumClueSound() && name.contains("scroll box (medium)")){
+		if (config.mediumClueSound() && (name.contains("scroll box (medium)") || name.contains("clue scroll (medium)"))){
 			playSound(MEDIUM_CLUE_SOUND_FILE);
 		}
-		if (config.hardClueSound() && name.contains("scroll box (hard)")){
+		if (config.hardClueSound() && (name.contains("scroll box (hard)") || name.contains("clue scroll (hard)"))){
 			playSound(HARD_CLUE_SOUND_FILE);
 		}
 
-		if (config.eliteClueSound() && name.contains("scroll box (elite)")){
+		if (config.eliteClueSound() && (name.contains("scroll box (elite)") || name.contains("clue scroll (elite)"))){
 			playSound(ELITE_CLUE_SOUND_FILE);
 		}
-		if (config.masterClueSound() && name.contains("scroll box (master)")){
+		if (config.masterClueSound() && (name.contains("scroll box (master)") || name.contains("clue scroll (master)"))){
 			playSound(MASTER_CLUE_SOUND_FILE);
 		}
 
@@ -454,6 +454,7 @@ public class CustomSoundsPlugin extends Plugin
 			highlightedItemsList = Text.fromCSV(groundItemsConfig.getHighlightItems().toLowerCase());
 		}
 	}
+
 	@Subscribe
 	public void onChatMessage(ChatMessage event) {
 		String chatMessage = event.getMessage();


### PR DESCRIPTION
Clue scrolls now drop in scroll boxes, the plugin no longer plays clue scroll sounds due to this. https://oldschool.runescape.wiki/w/Scroll_box